### PR TITLE
Add CORS and Spring Security config

### DIFF
--- a/spring-backend/.env.example
+++ b/spring-backend/.env.example
@@ -1,0 +1,4 @@
+db-user-password=USER_PASSWORD_HERE
+db-root-password=ROOT_PASSWORD_HERE
+db-host=localhost
+spring_profiles_active=dev

--- a/spring-backend/compose.yaml
+++ b/spring-backend/compose.yaml
@@ -12,6 +12,8 @@ services:
       blog-db:
         condition: service_healthy
         restart: true
+    environment:
+      - spring_profiles_active=${spring_profiles_active}
     secrets:
       - db-user-password
 

--- a/spring-backend/src/main/java/com/perfect8/blog/config/DevelopmentCorsConfig.java
+++ b/spring-backend/src/main/java/com/perfect8/blog/config/DevelopmentCorsConfig.java
@@ -1,0 +1,26 @@
+package com.perfect8.blog.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/// Development CORS config to allow API requests from a local frontend
+@Configuration
+@Profile("dev")
+public class DevelopmentCorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            public void addCorsMappings(@NotNull CorsRegistry registry) {
+                registry
+                        .addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}

--- a/spring-backend/src/main/java/com/perfect8/blog/config/SecurityConfig.java
+++ b/spring-backend/src/main/java/com/perfect8/blog/config/SecurityConfig.java
@@ -1,8 +1,23 @@
 package com.perfect8.blog.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@Profile("dev")
 public class SecurityConfig {
-    //TODO when we add Spring Security
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/posts/*")
+                        .permitAll() // View posts
+                )
+                .build();
+    }
 }


### PR DESCRIPTION
CORS config allows all hosts/methods when running on `dev` profile (not in production).

Spring Security config only allows `/posts/` endpoint for now.